### PR TITLE
Added max-age min+max coercion

### DIFF
--- a/cache_control_override.services.yml
+++ b/cache_control_override.services.yml
@@ -1,6 +1,7 @@
 services:
   cache_control_override.cache_control_override_subscriber:
     class: Drupal\cache_control_override\EventSubscriber\CacheControlOverrideSubscriber
+    arguments: ['@config.factory']
     tags:
       - { name: event_subscriber }
   cache_control_override.page_cache_response_policy.deny_on_cache_override:

--- a/config/schema/cache_control_override.schema.yml
+++ b/config/schema/cache_control_override.schema.yml
@@ -1,0 +1,13 @@
+cache_control_override.settings:
+  type: config_object
+  label: 'Cache control override settings'
+  mapping:
+    max_age:
+      type: mapping
+      mapping:
+        minimum:
+          type: integer
+          label: 'Minimum max age, if max age is greater than 0. Leave empty to disable.'
+        maximum:
+          type: integer
+          label: 'Maximum max age, if max age is greater than 0. Leave empty to disable.'

--- a/src/EventSubscriber/CacheControlOverrideSubscriber.php
+++ b/src/EventSubscriber/CacheControlOverrideSubscriber.php
@@ -61,11 +61,15 @@ class CacheControlOverrideSubscriber implements EventSubscriberInterface {
     // We treat permanent cache max-age as default therefore we don't override
     // the max-age.
     if ($max_age != Cache::PERMANENT) {
+      // If max-age is not uncacheable (0), check if max-age should be changed.
       if ($max_age > 0) {
+        // Force minimum max-age if configured.
         $minimum = $this->getMaxAgeMinimum();
         if (isset($minimum)) {
           $max_age = max($minimum, $max_age);
         }
+
+        // Force maximum max-age if configured.
         $maximum = $this->getMaxAgeMaximum();
         if (isset($maximum)) {
           $max_age = min($maximum, $max_age);

--- a/src/EventSubscriber/CacheControlOverrideSubscriber.php
+++ b/src/EventSubscriber/CacheControlOverrideSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\cache_control_override\EventSubscriber;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -12,6 +13,23 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Cache Control Override.
  */
 class CacheControlOverrideSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new CacheControlOverrideSubscriber.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory) {
+    $this->configFactory = $configFactory;
+  }
 
   /**
    * Overrides cache control header if any of override methods are enabled.
@@ -43,8 +61,38 @@ class CacheControlOverrideSubscriber implements EventSubscriberInterface {
     // We treat permanent cache max-age as default therefore we don't override
     // the max-age.
     if ($max_age != Cache::PERMANENT) {
+      if ($max_age > 0) {
+        $minimum = $this->getMaxAgeMinimum();
+        if (isset($minimum)) {
+          $max_age = max($minimum, $max_age);
+        }
+        $maximum = $this->getMaxAgeMaximum();
+        if (isset($maximum)) {
+          $max_age = min($maximum, $max_age);
+        }
+      }
       $response->headers->set('Cache-Control', 'public, max-age=' . $max_age);
     }
+  }
+
+  /**
+   * Get the minimum max-age.
+   *
+   * @return int|null
+   *   The minimum max-age, or null if no minimum.
+   */
+  protected function getMaxAgeMinimum() {
+    return $this->configFactory->get('cache_control_override.settings')->get('max_age.minimum');
+  }
+
+  /**
+   * Get the maximum max-age.
+   *
+   * @return int|null
+   *   The maximum max-age, or null if no maximum.
+   */
+  protected function getMaxAgeMaximum() {
+    return $this->configFactory->get('cache_control_override.settings')->get('max_age.maximum');
   }
 
   /**

--- a/tests/modules/cache_control_override_test/cache_control_override_test.routing.yml
+++ b/tests/modules/cache_control_override_test/cache_control_override_test.routing.yml
@@ -9,5 +9,6 @@ cache_control_override_test.max_age:
   path: '/cco/{max_age}'
   defaults:
     _controller: '\Drupal\cache_control_override_test\Controller\CacheControl::maxAge'
+    max_age: NULL
   requirements:
     _access: 'TRUE'

--- a/tests/modules/cache_control_override_test/src/Controller/CacheControl.php
+++ b/tests/modules/cache_control_override_test/src/Controller/CacheControl.php
@@ -16,7 +16,7 @@ class CacheControl {
    * Controller callback: Test content with a specified max age.
    *
    * @param int|null $max_age
-   *   Max age value to be used in the response.
+   *   Max-age value to be used in the response, or NULL to not a set max-age.
    *
    * @return array
    *   Render array of page output.

--- a/tests/modules/cache_control_override_test/src/Controller/CacheControl.php
+++ b/tests/modules/cache_control_override_test/src/Controller/CacheControl.php
@@ -2,28 +2,31 @@
 
 namespace Drupal\cache_control_override_test\Controller;
 
-use Drupal\Core\Cache\Cache;
-
 /**
  * Controllers for testing the cache control override.
  */
 class CacheControl {
 
   /**
+   * Content for testing.
+   */
+  const RESPONSE = 'Max age test content';
+
+  /**
    * Controller callback: Test content with a specified max age.
    *
-   * @param int $max_age
+   * @param int|null $max_age
    *   Max age value to be used in the response.
    *
    * @return array
    *   Render array of page output.
    */
-  public function maxAge($max_age = Cache::PERMANENT) {
-
-    return [
-      '#markup' => 'Max age test content',
-      '#cache' => ['max-age' => $max_age],
-    ];
+  public function maxAge($max_age = NULL) {
+    $build = ['#plain_text' => static::RESPONSE];
+    if (isset($max_age)) {
+      $build['#cache']['max-age'] = $max_age;
+    }
+    return $build;
   }
 
 }

--- a/tests/src/Functional/CacheControlOverrideMaxAgeTest.php
+++ b/tests/src/Functional/CacheControlOverrideMaxAgeTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\cache_control_override\Functional;
 
+use Drupal\cache_control_override_test\Controller\CacheControl;
 use Drupal\Tests\BrowserTestBase;
 
 /**
@@ -10,6 +11,11 @@ use Drupal\Tests\BrowserTestBase;
  * @group cache_control_override
  */
 class CacheControlOverrideMaxAgeTest extends BrowserTestBase {
+
+  /**
+   * The max age set by Drupal when page caching is enabled.
+   */
+  const DEFAULT_MAX_AGE = 1800;
 
   /**
    * {@inheritdoc}
@@ -26,7 +32,7 @@ class CacheControlOverrideMaxAgeTest extends BrowserTestBase {
     parent::setUp();
 
     $config = $this->config('system.performance');
-    $config->set('cache.page.max_age', 3600);
+    $config->set('cache.page.max_age', static::DEFAULT_MAX_AGE);
     $config->save();
   }
 
@@ -34,15 +40,80 @@ class CacheControlOverrideMaxAgeTest extends BrowserTestBase {
    * Test the cache properties in response header data.
    */
   public function testMaxAge() {
-
+    // Max age not set.
     $this->drupalGet('cco');
-    $this->assertSession()->responseContains('Max age test content');
-    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=3600, public');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . static::DEFAULT_MAX_AGE . ', public');
 
+    // Permanent.
+    $this->drupalGet('cco/-1');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . static::DEFAULT_MAX_AGE . ', public');
+
+    // Max age set.
     $this->drupalGet('cco/333');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
     $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=333, public');
 
+    // Uncacheable.
     $this->drupalGet('cco/0');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=0, public');
+  }
+
+  /**
+   * Test the max age is coerced to minimum age.
+   */
+  public function testMaxAgeMinimum() {
+    $assertMinimum = 100;
+    $this->config('cache_control_override.settings')
+      ->set('max_age.minimum', $assertMinimum)
+      ->save();
+
+    // Max-age must not be changed if not over minimum.
+    $this->drupalGet('cco/150');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=150, public');
+
+    // Max-age must be changed if under minimum.
+    $this->drupalGet('cco/50');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . $assertMinimum . ', public');
+
+    // Permanent or uncacheable must not be coerced.
+    $this->drupalGet('cco/-1');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . static::DEFAULT_MAX_AGE . ', public');
+    $this->drupalGet('cco/0');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=0, public');
+  }
+
+  /**
+   * Test the max age is coerced to maximum age.
+   */
+  public function testMaxAgeMaximum() {
+    $assertMaximum = 100;
+    $this->config('cache_control_override.settings')
+      ->set('max_age.maximum', $assertMaximum)
+      ->save();
+
+    // Max-age must not be changed if not under maximum.
+    $this->drupalGet('cco/50');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=50, public');
+
+    // Max-age must be changed if over maximum.
+    $this->drupalGet('cco/150');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . $assertMaximum . ', public');
+
+    // Permanent or uncacheable must not be coerced.
+    $this->drupalGet('cco/-1');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
+    $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=' . static::DEFAULT_MAX_AGE . ', public');
+    $this->drupalGet('cco/0');
+    $this->assertSession()->pageTextContains(CacheControl::RESPONSE);
     $this->assertSession()->responseHeaderContains('Cache-Control', 'max-age=0, public');
   }
 


### PR DESCRIPTION
UI-less:

```php
$config['cache_control_override.settings']['max_age']['minimum'] = 1000;
$config['cache_control_override.settings']['max_age']['maximum'] = 9000;
```